### PR TITLE
Added an 'accelerometer_mode' setting

### DIFF
--- a/premium/PiLR EMA/base-instrument.json
+++ b/premium/PiLR EMA/base-instrument.json
@@ -3,7 +3,7 @@
   "name": "PiLR EMA App",
   "description": "The PiLR EMA App allows you to setup surveys and messages to deliver to participants through their mobile phone (Android or iOS).  It also allows you to set a delivery schedule and triggering events to initiate them.",
   "code": "ema_ots",
-  "version": 3,
+  "version": 4,
   "customizations": {
     "package": "com.pilrhealth.instruments.ema_ots",
     "classnamePrefix": "EmaOts",
@@ -102,7 +102,20 @@
       "value": 0.2,
       "min": 0,
       "required": false
-    }
+    },
+    {
+			"type" : "list_setting",
+			"code" : "activity_monitoring:accelerometer_mode",
+			"name" : "Accelerometer Mode",
+			"description" : "Determines if the app uses an accelerometer, and which one.",
+			"choices" : [
+				"None",
+				"On Board Accelerometer",
+				"Actigraph Sensor"
+			],
+			"required" : false,
+			"multipleChoice" : false
+		}
   ],
   "datasets": [
     {


### PR DESCRIPTION
This is so that we can activate and set whether the app uses an onboard/external accelerometer.
